### PR TITLE
Enable basic auth env variable config

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"time"
+
+	types "github.com/openfaas/faas-provider/types"
+)
+
+type ProviderConfig struct {
+	// Sock is the address of the containerd socket
+	Sock string
+}
+
+// ReadFromEnv loads the FaaSConfig and the Containerd specific config form the env variables
+func ReadFromEnv(hasEnv types.HasEnv) (*types.FaaSConfig, *ProviderConfig, error) {
+	config, err := types.ReadConfig{}.Read(hasEnv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serviceTimeout := types.ParseIntOrDurationValue(hasEnv.Getenv("service_timeout"), time.Second*60)
+
+	config.EnableHealth = true
+	config.ReadTimeout = serviceTimeout
+	config.WriteTimeout = serviceTimeout
+
+	port := types.ParseIntValue(hasEnv.Getenv("port"), 8081)
+	config.TCPPort = &port
+
+	providerConfig := &ProviderConfig{
+		Sock: types.ParseString(hasEnv.Getenv("sock"), "/run/containerd/containerd.sock"),
+	}
+
+	return config, providerConfig, nil
+}

--- a/config/read_test.go
+++ b/config/read_test.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"strconv"
+	"testing"
+)
+
+type EnvBucket struct {
+	Items map[string]string
+}
+
+func NewEnvBucket() EnvBucket {
+	return EnvBucket{
+		Items: make(map[string]string),
+	}
+}
+
+func (e EnvBucket) Getenv(key string) string {
+	return e.Items[key]
+}
+
+func (e EnvBucket) Setenv(key string, value string) {
+	e.Items[key] = value
+}
+
+func Test_SetSockByEnv(t *testing.T) {
+	defaultSock := "/run/containerd/containerd.sock"
+	expectedSock := "/non/default/value.sock"
+	env := NewEnvBucket()
+	_, config, err := ReadFromEnv(env)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if config.Sock != defaultSock {
+		t.Fatalf("expected %q, got %q", defaultSock, config.Sock)
+	}
+
+	env.Setenv("sock", expectedSock)
+	_, config, err = ReadFromEnv(env)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if config.Sock != expectedSock {
+		t.Fatalf("expected %q, got %q", expectedSock, config.Sock)
+	}
+}
+
+func Test_SetServiceTimeout(t *testing.T) {
+	defaultTimeout := "1m0s"
+
+	env := NewEnvBucket()
+	config, _, err := ReadFromEnv(env)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if config.ReadTimeout.String() != defaultTimeout {
+		t.Fatalf("expected %q, got %q", defaultTimeout, config.ReadTimeout)
+	}
+
+	if config.WriteTimeout.String() != defaultTimeout {
+		t.Fatalf("expected %q, got %q", defaultTimeout, config.WriteTimeout)
+	}
+
+	newTimeout := "30s"
+	env.Setenv("service_timeout", newTimeout)
+	config, _, err = ReadFromEnv(env)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if config.ReadTimeout.String() != newTimeout {
+		t.Fatalf("expected %q, got %q", newTimeout, config.ReadTimeout)
+	}
+
+	if config.WriteTimeout.String() != newTimeout {
+		t.Fatalf("expected %q, got %q", newTimeout, config.WriteTimeout)
+	}
+}
+
+func Test_SetPort(t *testing.T) {
+	defaultPort := 8081
+
+	env := NewEnvBucket()
+	config, _, err := ReadFromEnv(env)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if config.TCPPort == nil {
+		t.Fatal("expected non-nil TCPPort")
+	}
+	if *config.TCPPort != defaultPort {
+		t.Fatalf("expected %d, got %d", defaultPort, config.TCPPort)
+	}
+
+	newPort := 9091
+	newPortStr := strconv.Itoa(newPort)
+	env.Setenv("port", newPortStr)
+	config, _, err = ReadFromEnv(env)
+	if err != nil {
+		t.Fatalf("unexpected error %s", err)
+	}
+	if config.TCPPort == nil {
+		t.Fatal("expected non-nil TCPPort")
+	}
+	if *config.TCPPort != newPort {
+		t.Fatalf("expected %d, got %d", newPort, config.TCPPort)
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Remove the duplicate boostrap config object
- Use the Read method from the faas-provider to load the FaasConfig object
- Create a config package and implement ReadFromEnv to centralize all of the config parsing and defaults in one location
- Add new ProvierConfig struct for containerd specific config values
- This matches the pattern that we use in the other providers of having the config parsing in a separate package.  It is slightly different in that it uses the `config` package and does not use the empty `ReadConfig` struct pattern

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change **this is required**

Resolves #10 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test have been added to the new config parsing. It only tests the customized values, since the provider package already tests config reading.

I also tested that faas-containerd then enforces the basic auth as expected:

```sh
$ echo admin >> basic-auth-user
$ echo localdev >> basic-auth-password

$ make local
$ sudo basic_auth=true secret_mount_path=`pwd` ./bin/faas-containerd &

$ faas-cli list -g 127.0.0.1:8081
Unauthorized access, run "faas-cli login" to setup authentication for this server

$ faas-cli login -u admin -p localdev -g 127.0.0.1:8081
WARNING! Using --password is insecure, consider using: cat ~/faas_pass.txt | faas-cli login -u user --password-stdin
Calling the OpenFaaS server to validate the credentials...
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
credentials saved for admin http://127.0.0.1:8081

$ faas-cli list -g 127.0.0.1:8081
Function                      	Invocations    	Replicas
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
