### PR TITLE
Fix CNI config load and configuration.

### DIFF
--- a/handlers/deploy.go
+++ b/handlers/deploy.go
@@ -139,7 +139,7 @@ func deploy(ctx context.Context, req types.FunctionDeployment, client *container
 	}
 
 	// Load the cni configuration
-	if err := cni.Load(gocni.WithLoNetwork, gocni.WithConfFile(filepath.Join(CNIConfDir, DefaultCNIConfFilename))); err != nil {
+	if err := cni.Load(gocni.WithLoNetwork, gocni.WithConfListFile(filepath.Join(CNIConfDir, DefaultCNIConfFilename))); err != nil {
 		log.Fatalf("failed to load cni configuration: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -27,23 +27,28 @@ var (
 )
 
 // defaultCNIConf is a CNI configuration that enables network access to containers (docker-bridge style)
-var defaultCNIConf = fmt.Sprintf(`{
-	"cniVersion": "0.4.0",
-	"name": "%s",
-	"type": "bridge",
-	"bridge": "%s",
-	"isGateway": true,
-	"isDefaultGateway": true,
-	"promiscMode": true,
-	"ipMasq": true,
-	"ipam": {
-		"type": "host-local",
-		"ranges": [
-			[{
-				"subnet": "%s"
-			}]
-		]
-	}
+var defaultCNIConf = fmt.Sprintf(`
+{
+    "cniVersion": "0.4.0",
+    "name": "%s",
+    "plugins": [
+      {
+        "type": "bridge",
+        "bridge": "%s",
+        "isGateway": true,
+        "ipMasq": true,
+        "ipam": {
+            "type": "host-local",
+            "subnet": "%s",
+            "routes": [
+                { "dst": "0.0.0.0/0" }
+            ]
+        }
+      },
+      {
+        "type": "firewall"
+      }
+    ]
 }
 `, handlers.DefaultNetworkName, handlers.DefaultBridgeName, handlers.DefaultSubnet)
 
@@ -81,18 +86,16 @@ func Start() {
 
 	netConfig := path.Join(handlers.CNIConfDir, handlers.DefaultCNIConfFilename)
 
-	if exists, _ := pathExists(netConfig); !exists {
-		log.Printf("Writing network config...\n")
-
-		if !dirExists(handlers.CNIConfDir) {
-			if err := os.MkdirAll(handlers.CNIConfDir, 0755); err != nil {
-				log.Fatalln(fmt.Errorf("cannot create directory: %s", handlers.CNIConfDir).Error())
-			}
+	log.Printf("Writing network config...\n")
+	if !dirExists(handlers.CNIConfDir) {
+		if err := os.MkdirAll(handlers.CNIConfDir, 0755); err != nil {
+			log.Fatalln(fmt.Errorf("cannot create directory: %s", handlers.CNIConfDir).Error())
 		}
+	}
 
-		if err := ioutil.WriteFile(netConfig, []byte(defaultCNIConf), 644); err != nil {
-			log.Fatalln(fmt.Errorf("cannot write network config: %s", handlers.DefaultCNIConfFilename).Error())
-		}
+	if err := ioutil.WriteFile(netConfig, []byte(defaultCNIConf), 644); err != nil {
+		log.Fatalln(fmt.Errorf("cannot write network config: %s", handlers.DefaultCNIConfFilename).Error())
+
 	}
 
 	serviceMap := handlers.NewServiceMap()


### PR DESCRIPTION
## Description

Fix behavior of CNI to allow communication between containers and load
correcty the config list of CNI plugins.

Overwrite the CNI config in case it exists. Allow updating the config
on new versions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change **this is required**


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Loading correct configuration and verifying communication between containers on same bridge.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Commits:

- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] My commit message has a body and describe how this was tested and why it is required.
- [x] I have signed-off my commits with `git commit -s` for the Developer Certificate of Origin (DCO)

Code:

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.

Docs:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
